### PR TITLE
Go router module mixin

### DIFF
--- a/prism_flutter_go_router/lib/modules/go_router_bootstrapper.dart
+++ b/prism_flutter_go_router/lib/modules/go_router_bootstrapper.dart
@@ -9,7 +9,7 @@ abstract class GoRouterBootstrapper extends GetItBootstrapper {
   Future<void> run() async {
     await super.run();
     final routes = modules
-        .whereType<GoRouterModule>()
+        .whereType<GoRouterModuleMixin>()
         .expand(
           (module) => module.configureRoutes(),
         )

--- a/prism_flutter_go_router/lib/modules/go_router_module.dart
+++ b/prism_flutter_go_router/lib/modules/go_router_module.dart
@@ -1,6 +1,9 @@
+import 'package:prism_flutter_core/modules/module.dart';
 import 'package:prism_flutter_getit/prism_flutter_getit.dart';
 import 'package:prism_flutter_go_router/interfaces/module_route.dart';
 
-abstract class GoRouterModule extends GetItModule {
+mixin GoRouterModuleMixin<T> on Module<T> {
   List<ModuleRoute> configureRoutes();
 }
+
+abstract class GoRouterModule extends GetItModule with GoRouterModuleMixin {}


### PR DESCRIPTION
Make GoRouterModuleMixin to allow modules with containers different than GetIt implement routing.